### PR TITLE
Change geometryID => geometryId

### DIFF
--- a/proto/sharedstreets.proto
+++ b/proto/sharedstreets.proto
@@ -44,7 +44,7 @@ message OSMMetadata {
 }
 
 message SharedStreetsMetadata {
-  string geometryID = 1;
+  string geometryId = 1;
 
   OSMMetadata osmMetadata = 2;
   repeated GISMetadata gisMetadata = 3;


### PR DESCRIPTION
Change geometryID => geometryId

Keeping casing consistent between SharedStreetsReference & SharedStreetsMetadata

```proto
message SharedStreetsReference {
  string id = 1;
  string geometryId = 2;

  enum FormOfWay {
    Undefined = 0;
    Motorway = 1;
    MultipleCarriageway = 2;
    SingleCarriageway = 3;
    Roundabout = 4;
    TrafficSquare = 5; // yikes: https://giphy.com/gifs/square-addis-meskel-GYb9s3Afw0cWA
    SlipRoad = 6;
    Other = 7;
  }
  FormOfWay formOfWay = 3;

  repeated LocationReference locationReferences = 4;
}
```

```proto
message SharedStreetsMetadata {
  string geometryId = 1;

  OSMMetadata osmMetadata = 2;
  repeated GISMetadata gisMetadata = 3;
}
```