### PR TITLE
Propose to change `Intersection.nodeId` type to String

### DIFF
--- a/proto/sharedstreets.proto
+++ b/proto/sharedstreets.proto
@@ -102,7 +102,7 @@ message SharedStreetsReference {
 
 message SharedStreetsIntersection {
   string id = 1;
-  uint64 nodeId = 2;
+  string nodeId = 2;
   double lon = 3;
   double lat = 4;
 


### PR DESCRIPTION
## Propose to change `Intersection.nodeId` type to String

Initially the `nodeId` was used to relate OpenStreetMap the node ID, however using a number would prevent any Id's which contain padded zeros, such as Quadkeys or any other schemas (ex: "000123").

If the `nodeId` data type remains as a Number, then `"000123"` would get converted to `123`.

I propose we change the data type of `nodeId` to `string` in the `SharedStreetsIntersection` proto file.

At the moment the `sharedstreets-pbf` outputs the `nodeId` as String (not too sure why it chose to output that data format, maybe the PBF data is already defined as a string?).

https://github.com/sharedstreets/sharedstreets-pbf/blob/master/test/out/11-602-769.intersection.json

@kpwebb Thoughts?