### PR TITLE
added osm tags to metadata tiles

### DIFF
--- a/proto/sharedstreets.proto
+++ b/proto/sharedstreets.proto
@@ -28,6 +28,11 @@ enum RoadClass {
   Other = 8;
 }
 
+message OsmTag {
+  string key  = 1;
+  string value  = 2;
+}
+
 message WaySection {
   uint64 wayId =1 ;
 
@@ -39,6 +44,8 @@ message WaySection {
   repeated uint64 nodeIds = 6;
   
   string name  = 7; // name only stored here if different for each way section, otherwise captured in OSMMetadata
+
+  repeated OsmTag tags = 8; // osm  tags
 }
 
 message OSMMetadata {


### PR DESCRIPTION
This change to the PBF file allows storage of all OSM way tags in the ShSt metadata tiles. Testing provisional changes to the build process to confirm this meets needs for tag analysis of OSM segments.